### PR TITLE
docs(scully): add info about database column naming conversion/convention

### DIFF
--- a/libs/scully-plugin-notion/README.md
+++ b/libs/scully-plugin-notion/README.md
@@ -49,7 +49,6 @@ npm install --save-dev @notion-stuff/scully-plugin-notion
   - `Published` status is required because this is being used by the plugin to set the `published` flag for a
     specific `ScullyRoute`. Although this is required for the plugin to work as expected, your intention (as plugin
     consumers) to use the `published` flag is totally up to you.
-  - Note: the text `Published` is case-sensitive to set the published flag along with the column name of `Status`.
 - `Slug` is utilized to setup the route to the post which is needed to be set manually as of the moment.
   - You can call `Slug` whatever you want but this needs to match `slugKey`
 

--- a/libs/scully-plugin-notion/src/lib/page-properties-to-frontmatter.ts
+++ b/libs/scully-plugin-notion/src/lib/page-properties-to-frontmatter.ts
@@ -16,9 +16,9 @@ export function pagePropertiesToFrontmatter(properties: PropertyValueMap) {
     const camelizedKey = camelize(propertyKey);
     frontmatter[camelizedKey] = parsePropertyValue(propertyValue);
 
-    if (propertyKey === 'Status') {
+    if (propertyKey.toLowerCase() === 'status') {
       frontmatter.published =
-        (propertyValue as PropertyValueSelect).select?.name === 'Published';
+        (propertyValue as PropertyValueSelect).select?.name.toLowerCase() === 'published';
     }
   }
 


### PR DESCRIPTION
describe how the database column names are converted to camelCase
along with noting that 'Status' and 'Published' are case sensitive