### PR TITLE
fix(html): handle undefined language param

### DIFF
--- a/libs/blocks-html-parser/src/lib/blocks-html-parser.ts
+++ b/libs/blocks-html-parser/src/lib/blocks-html-parser.ts
@@ -88,7 +88,7 @@ export class NotionBlocksHtmlParser {
 
     const codeTransformer = (code: unknown, language: string) => {
       const langClass =
-        'language-' + (language.includes('plain') ? 'none' : language);
+        'language-' + ( !language || language.includes('plain') ? 'none' : language);
       if (mdHighlightingOptions === 'hljs') {
         return `<pre><code class='hljs ${langClass}'>${
           (code as Record<string, unknown>).value


### PR DESCRIPTION
default to 'none' for language when language is not set