### PR TITLE
Use rich_text instead of text for all blocks which were renamed in the notion api

### DIFF
--- a/libs/blocks-markdown-parser/src/lib/blocks-markdown-parser.ts
+++ b/libs/blocks-markdown-parser/src/lib/blocks-markdown-parser.ts
@@ -169,7 +169,7 @@ export class NotionBlocksMarkdownParser {
     ) {
       text = '&nbsp;';
     } else {
-      text = this.parseRichTexts(paragraphBlock.paragraph.text);
+      text = this.parseRichTexts(paragraphBlock.paragraph.rich_text);
     }
 
     return EOL_MD.concat(text, EOL_MD);
@@ -183,7 +183,7 @@ ${(codeBlock.code.text[0] as RichTextText).text.content}
 
   parseQuoteBlock(quoteBlock: QuoteBlock): string {
     return EOL_MD.concat(
-      `> ${this.parseRichTexts(quoteBlock.quote.text)}`,
+      `> ${this.parseRichTexts(quoteBlock.quote.rich_text)}`,
       EOL_MD
     );
   }
@@ -192,7 +192,7 @@ ${(codeBlock.code.text[0] as RichTextText).text.content}
     const callout = `<div notion-callout>
   {{icon}}
   <span notion-callout-text>
-    ${this.parseRichTexts(calloutBlock.callout.text)}
+    ${this.parseRichTexts(calloutBlock.callout.rich_text)}
   </span>
 </div>`;
 
@@ -220,35 +220,35 @@ ${(codeBlock.code.text[0] as RichTextText).text.content}
     return EOL_MD.concat(
       '#'.repeat(headingLevel),
       ' ',
-      this.parseRichTexts(headingBlock[headingBlock.type].text),
+      this.parseRichTexts(headingBlock[headingBlock.type].rich_text),
       EOL_MD
     );
   }
 
   parseBulletedListItems(bulletedListItemBlock: BulletedListItemBlock): string {
     return '* '.concat(
-      this.parseRichTexts(bulletedListItemBlock.bulleted_list_item.text),
+      this.parseRichTexts(bulletedListItemBlock.bulleted_list_item.rich_text),
       EOL_MD
     );
   }
 
   parseNumberedListItems(numberedListItemBlock: NumberedListItemBlock): string {
     return '1. '.concat(
-      this.parseRichTexts(numberedListItemBlock.numbered_list_item.text),
+      this.parseRichTexts(numberedListItemBlock.numbered_list_item.rich_text),
       EOL_MD
     );
   }
 
   parseTodoBlock(todoBlock: ToDoBlock): string {
     return `- [${todoBlock.to_do.checked ? 'x' : ' '}] `.concat(
-      this.parseRichTexts(todoBlock.to_do.text),
+      this.parseRichTexts(todoBlock.to_do.rich_text),
       EOL_MD
     );
   }
 
   parseToggleBlock(toggleBlock: ToggleBlock): string {
     return `<details><summary>${this.parseRichTexts(
-      toggleBlock.toggle.text
+      toggleBlock.toggle.rich_text
     )}</summary>{{childBlock}}</details>`;
   }
 


### PR DESCRIPTION
The notion api has changed the field names from `text` to `rich_text` for some cases and this PR fixes this.